### PR TITLE
Add Optional Shuffle Mode for Audio Playback

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -17,7 +17,8 @@
         "folder1",
         "folder2",
         "folder2"
-      ]
+      ],
+      "shuffle": true
     }
   ]
 }

--- a/src/controller/MusicController.ts
+++ b/src/controller/MusicController.ts
@@ -11,7 +11,7 @@ export default class MusicController {
         const servers = get(config, "servers", []) as ServerInterface[];
 
         for (const server of servers) {
-            const {dir, ignore_directories, label, stream_key, url_rtmp} = server;
+            const {dir, ignore_directories, label, stream_key, url_rtmp, shuffle} = server;
 
             const refreshFiles = () => {
                 let files;
@@ -36,24 +36,31 @@ export default class MusicController {
                 if (isEmpty(files)) {
                     Logger.warn("⏳ File list is empty, trying again in 5 seconds...", label.toLowerCase());
                     setTimeout(() => {
-                        files = refreshFiles(); // Re-fetch files after 5 seconds delay
-                        playNext(); // Continue playback whether files are found or not
-                    }, 5000); // 5000 milliseconds = 5 seconds
-                    return; // Exit the current function and wait for setTimeout
+                        files = refreshFiles(); // Re-fetch files
+                        playNext(); // Continue playback
+                    }, 5000);
+                    return;
                 }
 
-                let randomValue = sample(files) as string;
+                // Check the shuffle setting from the config file
+                let nextFile = shuffle ? sample(files) as string : files.shift() as string;
 
-                new FfmpegStream(randomValue, server).stream(url_rtmp + stream_key, () => {
-                    Logger.info(`End file ` + basename(randomValue), label.toLowerCase());
-                    files = without(files, randomValue); // Remove the played music from the list
+                new FfmpegStream(nextFile, server).stream(url_rtmp + stream_key, () => {
+                    Logger.info(`End file ` + basename(nextFile), label.toLowerCase());
 
-                    playNext(); // Replay with next music file
+                    // Remove the played file
+                    if (!shuffle) {
+                        if (isEmpty(files)) {
+                            files = refreshFiles(); // Refill files when all are played
+                        }
+                    } else {
+                        files = without(files, nextFile);
+                    }
+
+                    playNext(); // Play next song
                 }, (err) => {
-                    // Handle errors in the stream (e.g. file not found or stream issues)
-                    Logger.error(`⛔ Streaming error for ${randomValue}: ${err.message}`, label.toLowerCase());
-                    files = refreshFiles(); // Attempt to refresh files if a stream error occurs
-                    playNext();
+                    Logger.error(`⛔ Streaming error for ${nextFile}: ${err.message}`, label.toLowerCase());
+                    playNext(); // Skip to the next song
                 });
             };
 

--- a/src/interfaces/ServerInterface.ts
+++ b/src/interfaces/ServerInterface.ts
@@ -10,5 +10,6 @@ export interface ServerInterface {
     "audio_channels": 1 | 2,
     "audio_bitrate": string,
     "scale": string,
-    "ignore_directories": string[]
+    "ignore_directories": string[],
+    "shuffle": boolean
 }


### PR DESCRIPTION
This PR introduces a configurable shuffle mode for audio playback. Previously, tracks were always played in a random order. Now, users can choose between shuffle mode or sequential playback by setting the "shuffle" option in config.json.

Key Changes:
✅ Added a "shuffle" option in config.json (default: true).
✅ Updated MusicController to respect the shuffle setting.
✅ If "shuffle": false, tracks play in order; otherwise, they shuffle.
✅ Improved error handling to ensure smooth playback.

How to Test:
Set "shuffle": true in config.json → Tracks should play randomly.
Set "shuffle": false in config.json → Tracks should play in order.